### PR TITLE
Add Label Margins, Attributed String, and Text Alignment Options

### DIFF
--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -280,6 +280,12 @@ NSString *const kContinueLabelText = @"Tap to continue";
   NSTextAlignment textAlignment = [[markDef objectForKey:@"textAlignment"] integerValue];
   self.lblCaption.textAlignment = textAlignment;
   
+  CGFloat labelMargin = kLabelMargin;
+  NSNumber *customMargin = [markDef objectForKey:@"labelMargin"];
+  if (customMargin) {
+    labelMargin = [customMargin doubleValue];
+  }
+  
   if (markCaption) {
     self.lblCaption.text = markCaption;
   }
@@ -300,10 +306,10 @@ NSString *const kContinueLabelText = @"Tap to continue";
   //Label Aligment and Position
   switch (labelAlignment) {
     case LABEL_ALIGNMENT_RIGHT:
-      x = floorf(self.bounds.size.width - self.lblCaption.frame.size.width - kLabelMargin);
+      x = floorf(self.bounds.size.width - self.lblCaption.frame.size.width - labelMargin);
       break;
     case LABEL_ALIGNMENT_LEFT:
-      x = kLabelMargin;
+      x = labelMargin;
       break;
     default:
       x = floorf((self.bounds.size.width - self.lblCaption.frame.size.width) / 2.0f);
@@ -313,14 +319,14 @@ NSString *const kContinueLabelText = @"Tap to continue";
   switch (labelPosition) {
     case LABEL_POSITION_TOP:
     {
-      y = markRect.origin.y - self.lblCaption.frame.size.height - kLabelMargin;
+      y = markRect.origin.y - self.lblCaption.frame.size.height - labelMargin;
       if(showArrow) {
         self.arrowImage = [[UIImageView alloc] initWithImage:[self fetchImage:@"arrow-down"]];
         CGRect imageViewFrame = self.arrowImage.frame;
         imageViewFrame.origin.x = x;
         imageViewFrame.origin.y = y;
         self.arrowImage.frame = imageViewFrame;
-        y -= (self.arrowImage.frame.size.height + kLabelMargin);
+        y -= (self.arrowImage.frame.size.height + labelMargin);
         [self addSubview:self.arrowImage];
       }
     }
@@ -328,14 +334,14 @@ NSString *const kContinueLabelText = @"Tap to continue";
     case LABEL_POSITION_LEFT:
     {
       y = markRect.origin.y + markRect.size.height/2 - self.lblCaption.frame.size.height/2;
-      x = self.bounds.size.width - self.lblCaption.frame.size.width - kLabelMargin - markRect.size.width;
+      x = self.bounds.size.width - self.lblCaption.frame.size.width - labelMargin - markRect.size.width;
       if(showArrow) {
         self.arrowImage = [[UIImageView alloc] initWithImage:[self fetchImage:@"arrow-right"]];
         CGRect imageViewFrame = self.arrowImage.frame;
-        imageViewFrame.origin.x = self.bounds.size.width - self.arrowImage.frame.size.width - kLabelMargin - markRect.size.width;
+        imageViewFrame.origin.x = self.bounds.size.width - self.arrowImage.frame.size.width - labelMargin - markRect.size.width;
         imageViewFrame.origin.y = y + self.lblCaption.frame.size.height/2 - imageViewFrame.size.height/2;
         self.arrowImage.frame = imageViewFrame;
-        x -= (self.arrowImage.frame.size.width + kLabelMargin);
+        x -= (self.arrowImage.frame.size.width + labelMargin);
         [self addSubview:self.arrowImage];
       }
     }
@@ -343,7 +349,7 @@ NSString *const kContinueLabelText = @"Tap to continue";
     case LABEL_POSITION_RIGHT:
     {
       y = markRect.origin.y + markRect.size.height/2 - self.lblCaption.frame.size.height/2;
-      x = markRect.origin.x + markRect.size.width + kLabelMargin;
+      x = markRect.origin.x + markRect.size.width + labelMargin;
       if(showArrow) {
         
       }
@@ -356,12 +362,12 @@ NSString *const kContinueLabelText = @"Tap to continue";
       if (bottomY > self.bounds.size.height) {
         y = markRect.origin.y - self.lblSpacing - self.lblCaption.frame.size.height;
       }
-      x = markRect.origin.x + markRect.size.width + kLabelMargin;
+      x = markRect.origin.x + markRect.size.width + labelMargin;
       if(showArrow) {
         self.arrowImage = [[UIImageView alloc] initWithImage:[self fetchImage:@"arrow-top"]];
         CGRect imageViewFrame = self.arrowImage.frame;
         imageViewFrame.origin.x = x - markRect.size.width/2 - imageViewFrame.size.width/2;
-        imageViewFrame.origin.y = y - kLabelMargin; //self.lblCaption.frame.size.height/2
+        imageViewFrame.origin.y = y - labelMargin; //self.lblCaption.frame.size.height/2
         y += imageViewFrame.size.height/2;
         self.arrowImage.frame = imageViewFrame;
         [self addSubview:self.arrowImage];
@@ -380,7 +386,7 @@ NSString *const kContinueLabelText = @"Tap to continue";
         imageViewFrame.origin.x = x;
         imageViewFrame.origin.y = y;
         self.arrowImage.frame = imageViewFrame;
-        y += (self.arrowImage.frame.size.height + kLabelMargin);
+        y += (self.arrowImage.frame.size.height + labelMargin);
         [self addSubview:self.arrowImage];
       }
     }

--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -270,8 +270,6 @@ NSString *const kContinueLabelText = @"Tap to continue";
     [self addSubview:currentView];
   }
   
-  
-  
   [self.arrowImage removeFromSuperview];
   BOOL showArrow = NO;
   if( [markDef objectForKey:@"showArrow"])

--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -277,6 +277,9 @@ NSString *const kContinueLabelText = @"Tap to continue";
   if( [markDef objectForKey:@"showArrow"])
     showArrow = [[markDef objectForKey:@"showArrow"] boolValue];
   
+  NSTextAlignment textAlignment = [[markDef objectForKey:@"textAlignment"] integerValue];
+  self.lblCaption.textAlignment = textAlignment;
+  
   if (markCaption) {
     self.lblCaption.text = markCaption;
   }

--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -342,6 +342,14 @@ NSString *const kContinueLabelText = @"Tap to continue";
         x -= (self.arrowImage.frame.size.width + labelMargin);
         [self addSubview:self.arrowImage];
       }
+      // if the mark goes off-screen, bring it back on and reduce its width
+      if (x < 0) {
+        CGRect currentFrame = self.lblCaption.frame;
+        CGFloat newWidth = currentFrame.size.width - (abs(x) + labelMargin);
+        x = labelMargin;
+        self.lblCaption.frame = CGRectMake(x, currentFrame.origin.y, newWidth, currentFrame.size.height);
+        [self.lblCaption sizeToFit];
+      }
     }
       break;
     case LABEL_POSITION_RIGHT:

--- a/MPCoachMarks/MPCoachMarks.m
+++ b/MPCoachMarks/MPCoachMarks.m
@@ -227,6 +227,8 @@ NSString *const kContinueLabelText = @"Tap to continue";
   // Coach mark definition
   NSDictionary *markDef = [self.coachMarks objectAtIndex:index];
   NSString *markCaption = [markDef objectForKey:@"caption"];
+  NSAttributedString *markAttributedCaption = [markDef objectForKey:@"attributedCaption"];
+  
   CGRect markRect = [[markDef objectForKey:@"rect"] CGRectValue];
   
   MaskShape shape = DEFAULT;
@@ -275,11 +277,18 @@ NSString *const kContinueLabelText = @"Tap to continue";
   if( [markDef objectForKey:@"showArrow"])
     showArrow = [[markDef objectForKey:@"showArrow"] boolValue];
   
+  if (markCaption) {
+    self.lblCaption.text = markCaption;
+  }
+  
+  if (markAttributedCaption) {
+    self.lblCaption.attributedText = markAttributedCaption;
+  }
   
   // Calculate the caption position and size
   self.lblCaption.alpha = 0.0f;
   self.lblCaption.frame = (CGRect){{0.0f, 0.0f}, {self.maxLblWidth, 0.0f}};
-  self.lblCaption.text = markCaption;
+  
   [self.lblCaption sizeToFit];
   CGFloat y;
   CGFloat x;


### PR DESCRIPTION
This adds a few options to `MPCoachMarks`:
1. Label Margin - the default distance between the label and the highlighted mark is 5 points and there doesn't seem to be a way to override it. This adds a `labelMargin` option per Mark that allows you to control the distance between the label and the highlighted mark.
2. Attributed String - the default mark only allows passing a string. This adds an `attributedCaption` so consumers can pass in attributed strings as captions
3. Text Alignment - As far as I can tell, the default label mark will always be center-aligned. This adds a `textAlignment` option to control the label alignment. This is different from the `alignment` option, which I can't figure out what it does at all.

Combined, it allows cool things like this:

![screen shot 2017-05-15 at 5 01 09 pm](https://cloud.githubusercontent.com/assets/51138/26084313/1b22c540-3990-11e7-82ba-5d0153ce69ec.png)